### PR TITLE
Some fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,11 +21,14 @@ pipeline {
         }
         stage('Docker image building') {
             when {
-                anyOf {
-                   branch 'master'
-                   branch 'test'
-                   buildingTag()
-               }
+                allOf {
+                    changeset 'Dockerfile'
+                    anyOf {
+                        branch 'master'
+                        branch 'test'
+                        buildingTag()
+                    }
+                }
             }
             steps{
                 checkout scm
@@ -78,11 +81,14 @@ pipeline {
 
         stage('Docker Hub delivery') {
             when {
-                anyOf {
-                   branch 'master'
-                   branch 'test'
-                   buildingTag()
-               }
+                allOf {
+                    changeset 'Dockerfile'
+                    anyOf {
+                        branch 'master'
+                        branch 'test'
+                        buildingTag()
+                    }
+                }
             }
             steps{
                 script {
@@ -102,7 +108,10 @@ pipeline {
 
         stage("Render metadata on the marketplace") {
             when {
-                branch 'master'
+                allOf {
+                    branch 'master'
+                    changeset 'metadata.json'
+                }
             }
             steps {
                 script {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+<div align="center">
+<img src="https://marketplace.deep-hybrid-datacloud.eu/images/logo-deep.png" alt="logo" width="300"/>
+</div>
+
 DEEP-OC-dogs_breed_det
 ============================================
-
-![DEEP-Hybrid-DataCloud logo](https://docs.deep-hybrid-datacloud.eu/en/latest/_static/logo.png)
 
 [![Build Status](https://jenkins.indigo-datacloud.eu/buildStatus/icon?job=Pipeline-as-code%2FDEEP-OC-org%2FDEEP-OC-dogs_breed_det%2Fmaster)](https://jenkins.indigo-datacloud.eu/job/Pipeline-as-code/job/DEEP-OC-org/job/DEEP-OC-dogs_breed_det/job/master/)
 

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
            "(VGG16 | VGG19 | Resnet50 | InceptionV3)[CNN models] the last layer is removed, ", 
            "then two new Fully Connected (FC) layers are added, which are trained. ",
            "",
-           "Original dataset [dogs-aws] consists of 8351 dog’s images for 133 breeds divided into ",
+           "Original dataset [dogs-aws] consists of 8351 dog's images for 133 breeds divided into ",
            "training set (6680 pictures), validation set (835), and test set (836), and amounts for 1080 MB in zipped format.",
            "",
 		"**References**\n",


### PR DESCRIPTION
Hi Valentin,

I made a few changes:
* I normalized the logo like other repositories
* I added some additional conditions in the Jenkinsfile that I have been testing with Pablo so that the Docker image is not rebuild if only the `metadata.json` is updated
* I corrected a non-ASCII character you had in the `metadata.json` that was [preventing the html build](https://jenkins.indigo-datacloud.eu/job/Pipeline-as-code/job/deephdc.github.io/job/pelican/32/execution/node/44/log/). For the next time you can check for non-ASCII characters with the following command:
 `grep --color='auto' -P -n '[^\x00-\x7F]' metadata.json`